### PR TITLE
fix: 4k stream support within browser env on tizen 8/9

### DIFF
--- a/lib/device/tizen.js
+++ b/lib/device/tizen.js
@@ -111,7 +111,11 @@ shaka.device.Tizen = class extends shaka.device.AbstractDevice {
    * @override
    */
   detectMaxHardwareResolution() {
-    const maxResolution = {width: 1920, height: 1080};
+    const devicePixelRatio = window.devicePixelRatio;
+    const maxResolution = {
+      width: window.screen.width * devicePixelRatio > 1920 ? 3840 : 1920,
+      height: window.screen.height * devicePixelRatio > 1080 ? 2160 : 1080
+    };
     try {
       if (webapis.systeminfo && webapis.systeminfo.getMaxVideoResolution) {
         const maxVideoResolution =


### PR DESCRIPTION
Earlier this year #8365 provided a solution to the maxResolution detection on Tizen devices.  This was then refactored into the device api under #8210 but the earlier fix was not propagated.  This PR reinstates it.